### PR TITLE
Improvement#1939 add multi sort support to

### DIFF
--- a/src/aggregateMulti.ts
+++ b/src/aggregateMulti.ts
@@ -1,0 +1,131 @@
+import _ from 'underscore';
+import { Collection } from 'mongodb';
+
+import config from './config';
+import {
+  prepareResponse,
+  generateSort,
+  generateCursorQuery,
+  filterProjectedFields,
+  generateSorts,
+  generateCursorQueryMulti,
+} from './utils/query';
+import sanitizeParams, { sanitizeMultiParamsMutate } from './utils/sanitizeParams';
+import { AggregateParams, AggregateParamsMulti, PaginationResponse } from './types';
+
+/**
+ * Performs an aggregate() query on a passed-in Mongo collection, using criteria you specify.
+ * Unlike `find()`, this method requires fine tuning by the user, and must comply with the following
+ * two criteria so that the pagination magic can work properly.
+ *
+ * 1. `aggregate()` will insert a `$sort` and `$limit` clauses in your aggregation pipeline immediately after
+ * the first $match is found. Consider this while building your pipeline.
+ *
+ * 2. The documents resulting from the aggregation _must_ contain the paginated fields so that a
+ * cursor can be built from the result set.
+ *
+ * Additionally, an additional query will be appended to the first `$match` found in order to apply the offset
+ * required for the cursor.
+ *
+ * @param {MongoCollection} collection A collection object returned from the MongoDB library's.
+ * @param {AggregateParams} params
+ *    -aggregation {Object[]} The aggregation query.
+ *    -limit {Number} The page size. Must be between 1 and `config.MAX_LIMIT`.
+ *    -paginatedField {String} The field name to query the range for. The field must be:
+ *        1. Orderable. We must sort by this value. If duplicate values for paginatedField field
+ *          exist, the results will be secondarily ordered by the _id.
+ *        2. Immutable. If the value changes between paged queries, it could appear twice.
+ *        3. Accessible. The field must be present in the aggregation's end result so the
+ *          aggregation steps added at the end of the pipeline to implement the paging can access it.
+          4. Consistent. All values (except undefined and null values) must be of the same type.
+ *      The default is to use the Mongo built-in '_id' field, which satisfies the above criteria.
+ *      The only reason to NOT use the Mongo _id field is if you chose to implement your own ids.
+ *    -sortAscending {boolean} Whether to sort in ascending order by the `paginatedField`.
+ *    -sortCaseInsensitive {boolean} Whether to ignore case when sorting, in which case `paginatedField`
+ *      must be a string property.
+ *    -next {String} The value to start querying the page.
+ *    -previous {String} The value to start querying previous page.
+ *    -after {String} The _id to start querying the page.
+ *    -before {String} The _id to start querying previous page.
+ *    -options {Object} Aggregation options
+ *    -collation {Object} An optional collation to provide to the mongo query. E.g. { locale: 'en', strength: 2 }. When null, disables the global collation.
+ */
+export default async (
+  collection: Collection | any,
+  params: AggregateParamsMulti
+): Promise<PaginationResponse> => {
+  const projectedFields = params.fields;
+
+  params = _.defaults(await sanitizeMultiParamsMutate(collection, params), { aggregation: [] });
+  const $match = generateCursorQueryMulti(params);
+  const $sort = generateSorts(params);
+  const $limit = params.limit + 1;
+
+  const isCaseInsensitive = params.paginatedFields.some((pf) => pf.sortCaseInsensitive);
+
+  const aggregationQuery = (() => {
+    const { aggregation } = params;
+
+    if (!isCaseInsensitive) return [...aggregation, { $match }, { $sort }, { $limit }];
+
+    // else if required to be sorted by lower case, then add a field via the aggregation
+    // pipeline that stores the lowercase value of the paginated field. Use this to sort
+    // and add to cursors, but return the original paginated field value to client.
+    const addLowerCaseFieldSearch = {
+      $addFields: {
+        __lower_case_value: {
+          $switch: {
+            branches: Object.assign(
+              [],
+              ...params.paginatedFields.map((pf) => [
+                { case: { $eq: [{ $type: `$${pf.paginatedField}` }, 'null'] }, then: null },
+                { case: { $eq: [{ $type: `$${pf.paginatedField}` }, 'missing'] }, then: null },
+                {
+                  case: { $eq: [{ $type: `$${pf.paginatedField}` }, 'string'] },
+                  then: { $toLower: `$${pf.paginatedField}` },
+                },
+              ])
+            ),
+
+            default: `$${params.paginatedFields[0].paginatedField}`,
+          },
+        },
+      },
+    };
+
+    return [...aggregation, addLowerCaseFieldSearch, { $match }, { $sort }, { $limit }];
+  })();
+
+  // Aggregation options:
+  // https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#aggregate
+  // https://mongodb.github.io/node-mongodb-native/4.0/interfaces/aggregateoptions.html
+  const options = Object.assign({}, params.options);
+
+  /**
+   * IMPORTANT
+   *
+   * If using collation, check the README:
+   * https://github.com/mixmaxhq/mongo-cursor-pagination#important-note-regarding-collation
+   */
+  const isCollationNull = params.collation === null;
+  const collation = params.collation || config.COLLATION;
+  if (collation && !isCollationNull) options.collation = collation;
+
+  if (params.hint) options.hint = params.hint;
+
+  // Support both the native 'mongodb' driver and 'mongoist'. See:
+  // https://www.npmjs.com/package/mongoist#cursor-operations
+  const aggregateMethod = collection.aggregateAsCursor ? 'aggregateAsCursor' : 'aggregate';
+
+  const results = await collection[aggregateMethod](aggregationQuery, options).toArray();
+
+  const response = prepareResponse(results, params);
+
+  const projectedResults = filterProjectedFields({
+    projectedFields,
+    results: response.results,
+    sortCaseInsensitive: isCaseInsensitive,
+  });
+
+  return { ...response, results: projectedResults };
+};

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,5 +11,5 @@ export default {
    */
   DEFAULT_LIMIT: 50,
 
-  COLLATION: { locale: 'en' } as CollationOptions | undefined,
+  COLLATION: undefined as CollationOptions | undefined,
 };

--- a/src/find.ts
+++ b/src/find.ts
@@ -59,7 +59,6 @@ export default async (
   } else {
     // Need to repeat `params.paginatedField` default value ('_id') since it's set in 'sanitizeParams()'
     params = _.defaults(await sanitizeParams(collection, params), { query: {} });
-
     const cursorQuery = generateCursorQuery(params);
     const $sort = generateSort(params);
 

--- a/src/findMulti.ts
+++ b/src/findMulti.ts
@@ -74,11 +74,8 @@ export default async (
     const findMethod = collection.findAsCursor ? 'findAsCursor' : 'find';
 
     const query = collection[findMethod]()?.project
-      ? collection
-          .find({ $and: [cursorQuerys, params.query] })
-          .project(params.fields)
-          .sort($sort)
-      : collection[findMethod]({ $and: [cursorQuerys, params.query] }, params.fields, $sort);
+      ? collection.find({ $and: [cursorQuerys, params.query] }).project(params.fields)
+      : collection[findMethod]({ $and: [cursorQuerys, params.query] }, params.fields);
 
     /**
      * IMPORTANT

--- a/src/findMulti.ts
+++ b/src/findMulti.ts
@@ -64,9 +64,7 @@ export default async (
   } else {
     // Need to repeat `params.paginatedField` default value ('_id') since it's set in 'sanitizeParams()'
     params = _.defaults(await sanitizeMultiParamsMutate(collection, params), { query: {} });
-
     const cursorQuerys = generateCursorQueryMulti(params);
-
     const $sort = generateSorts(params);
 
     // Support both the native 'mongodb' driver and 'mongoist'. See:

--- a/src/findMulti.ts
+++ b/src/findMulti.ts
@@ -49,10 +49,9 @@ export default async (
   params: QueryParamsMulti
 ): Promise<PaginationResponse> => {
   const projectedFields = params.fields;
-
-  // TODO: refactor this to handle a multiple sort
   let response = {} as PaginationResponse;
-  const isCaseInsensitive = params.paginatedFields.some((pf) => pf.sortCaseInsensitive);
+  const isCaseInsensitive = params.paginatedFields?.some((pf) => pf.sortCaseInsensitive);
+
   if (isCaseInsensitive) {
     // For case-insensitive sorting, we need to work with an aggregation:
     response = await aggregateMulti(
@@ -86,10 +85,11 @@ export default async (
     const collatedQuery = collation && !isCollationNull ? query.collation(collation) : query;
     // Query one more element to see if there's another page.
     const cursor = collatedQuery.sort($sort).limit(params.limit + 1);
+
     if (params.hint) cursor.hint(params.hint);
     const results = await cursor.toArray();
 
-    response = prepareResponse(results, params);
+    response = prepareResponse(results, params, true);
     if (params.getTotal) response.totalCount = await collection.countDocuments(params.query);
   }
 

--- a/src/findMulti.ts
+++ b/src/findMulti.ts
@@ -1,0 +1,106 @@
+import _ from 'underscore';
+
+import aggregate from './aggregate';
+import config from './config';
+import {
+  prepareResponse,
+  generateSort,
+  generateCursorQuery,
+  filterProjectedFields,
+  generateCursorQueryMulti,
+  generateSorts,
+} from './utils/query';
+import sanitizeParams, { sanitizeMultiParamsMutate } from './utils/sanitizeParams';
+import { QueryParams, PaginationResponse, QueryParamsMulti } from './types';
+import { Collection } from 'mongodb';
+
+/**
+ * Performs a find() query on a passed-in Mongo collection, using criteria you specify. The results
+ * are ordered by the paginatedField.
+ *
+ * @param {MongoCollection} collection A collection object returned from the MongoDB library's.
+ * @param {QueryParams} params
+ *    -query {Object} The find query.
+ *    -limit {Number} The page size. Must be between 1 and `config.MAX_LIMIT`.
+ *    -fields {Object} Fields to query in the Mongo object format, e.g. {_id: 1, timestamp :1}.
+ *      The default is to query all fields.
+ *    -paginatedField {String} The field name to query the range for. The field must be:
+ *        1. Orderable. We must sort by this value. If duplicate values for paginatedField field
+ *          exist, the results will be secondarily ordered by the _id.
+ *        2. Indexed. For large collections, this should be indexed for query performance.
+ *        3. Immutable. If the value changes between paged queries, it could appear twice.
+          4. Consistent. All values (except undefined and null values) must be of the same type.
+ *      The default is to use the Mongo built-in '_id' field, which satisfies the above criteria.
+ *      The only reason to NOT use the Mongo _id field is if you chose to implement your own ids.
+ *    -sortAscending {boolean} Whether to sort in ascending order by the `paginatedField`.
+ *    -sortCaseInsensitive {boolean} Whether to ignore case when sorting, in which case `paginatedField`
+ *    -getTotal {boolean} Whether to fetch the total count for the query results
+ *      must be a string property.
+ *    -next {String} The value to start querying the page.
+ *    -previous {String} The value to start querying previous page.
+ *    -after {String} The _id to start querying the page.
+ *    -before {String} The _id to start querying previous page.
+ *    -hint {String} An optional index hint to provide to the mongo query
+ *    -collation {Object} An optional collation to provide to the mongo query. E.g. { locale: 'en', strength: 2 }. When null, disables the global collation.
+ */
+export default async (
+  collection: Collection | any,
+  params: QueryParamsMulti
+): Promise<PaginationResponse> => {
+  const projectedFields = params.fields;
+
+  // TODO: refactor this to handle a multiple sort
+
+  const isCaseInsensitive = params.paginatedFields.some((pf) => pf.sortCaseInsensitive);
+
+  let response = {} as PaginationResponse;
+  if (isCaseInsensitive) {
+    // For case-insensitive sorting, we need to work with an aggregation:
+    response = await aggregate(
+      collection,
+      Object.assign({}, params, {
+        aggregation: params.query ? [{ $match: params.query }] : [],
+      })
+    );
+  } else {
+    // Need to repeat `params.paginatedField` default value ('_id') since it's set in 'sanitizeParams()'
+    params = _.defaults(await sanitizeMultiParamsMutate(collection, params), { query: {} });
+
+    const cursorQuerys = generateCursorQueryMulti(params);
+    const $sort = generateSorts(params);
+
+    // Support both the native 'mongodb' driver and 'mongoist'. See:
+    // https://www.npmjs.com/package/mongoist#cursor-operations
+    const findMethod = collection.findAsCursor ? 'findAsCursor' : 'find';
+
+    const query = collection[findMethod]()?.project
+      ? collection.find({ $and: [cursorQuerys, params.query] }).project(params.fields)
+      : collection[findMethod]({ $and: [cursorQuerys, params.query] }, params.fields);
+
+    /**
+     * IMPORTANT
+     *
+     * If using collation, check the README:
+     * https://github.com/mixmaxhq/mongo-cursor-pagination#important-note-regarding-collation
+     */
+    const isCollationNull = params.collation === null;
+    const collation = params.collation || config.COLLATION;
+    const collatedQuery = collation && !isCollationNull ? query.collation(collation) : query;
+    // Query one more element to see if there's another page.
+    const cursor = collatedQuery.sort($sort).limit(params.limit + 1);
+    if (params.hint) cursor.hint(params.hint);
+    const results = await cursor.toArray();
+
+    response = prepareResponse(results, params);
+    if (params.getTotal) response.totalCount = await collection.countDocuments(params.query);
+  }
+
+  // Remove fields that we added to the query (such as paginatedField and _id) that the user didn't ask for.
+  const projectedResults = filterProjectedFields({
+    projectedFields,
+    results: response.results,
+    sortCaseInsensitive: isCaseInsensitive,
+  });
+
+  return { ...response, results: projectedResults };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import aggregate from './aggregate';
 import config from './config';
 import find from './find';
+import findMulti from './findMulti';
 import findWithReq from './findWithReq';
 import mongoosePlugin from './mongoose.plugin';
 import search from './search';
@@ -11,6 +12,7 @@ export {
   config,
   find,
   findWithReq,
+  findMulti,
   aggregate,
   search,
   mongoosePlugin,

--- a/src/mongoose.plugin.ts
+++ b/src/mongoose.plugin.ts
@@ -102,6 +102,6 @@ export default (schema: Schema, options: Options) => {
   if (options && options.findMultiFnName) {
     schema.statics[options.findMultiFnName] = findMultiFn;
   } else {
-    schema.statics.findMulti = findMultiFn;
+    schema.statics.paginateMulti = findMultiFn;
   }
 };

--- a/src/types/Options.ts
+++ b/src/types/Options.ts
@@ -1,4 +1,5 @@
 export type Options = {
   name: string;
   searchFnName: string;
+  findMultiFnName: string;
 };

--- a/src/types/queries.ts
+++ b/src/types/queries.ts
@@ -14,6 +14,17 @@ interface BaseParams {
   hint?: string;
 }
 
+type BaseParamsMulti = Omit<
+  BaseParams,
+  'paginatedField' | 'sortAscending' | 'sortCaseInsensitive'
+> & { paginatedFields?: PaginatedField[] };
+
+export interface PaginatedField {
+  paginatedField?: string;
+  sortAscending?: boolean;
+  sortCaseInsensitive?: boolean;
+}
+
 interface Query {
   query?: object;
   next?: string | Document;
@@ -44,6 +55,8 @@ interface AggregateInput {
 
 export type QueryInputParams = BaseParams & QueryInput;
 export type QueryParams = BaseParams & Query;
+export type QueryParamsMulti = BaseParamsMulti & Query;
+export type QueryInputParamsMulti = BaseParamsMulti & QueryInput;
 
 export type AggregateInputParams = BaseParams & AggregateInput;
 export type AggregateParams = BaseParams & Aggregate;

--- a/src/types/queries.ts
+++ b/src/types/queries.ts
@@ -61,6 +61,9 @@ export type QueryInputParamsMulti = BaseParamsMulti & QueryInput;
 export type AggregateInputParams = BaseParams & AggregateInput;
 export type AggregateParams = BaseParams & Aggregate;
 
+export type AggregateInputParamsMulti = BaseParamsMulti & AggregateInput;
+export type AggregateParamsMulti = BaseParamsMulti & Aggregate;
+
 export type SearchParams = {
   query?: object;
   limit?: number;

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -267,10 +267,22 @@ export function generateCursorQueryMulti(params: QueryParamsMulti) {
   return { $or: bigOr };
 }
 
-function $gtOr$lt(asc: boolean) {
+function $gt$lt(asc: boolean) {
   return asc ? '$gt' : '$lt';
 }
 
+/**
+ * Takes the previous entires and adds a new one where
+ * all of the operators are $eq excpet the latest
+ *
+ * i.e.
+ * ```
+ *  //before
+ *  { firstName: { $gt: "george" } }
+ *  // after
+ *  { firstName: { $eq: "george" }, { lastName: {$gt: "Costanza" } }
+ * ```
+ */
 function getOrNextLine(
   prev: Record<string, any>,
   field: string,
@@ -278,15 +290,25 @@ function getOrNextLine(
   value: string
 ): Record<string, any> {
   if (!prev) {
-    return { [field]: { [$gtOr$lt(sortAsc)]: value } };
+    return { [field]: { [$gt$lt(sortAsc)]: value } };
   }
   const previousFields = Object.assign(
     {},
     ...Object.entries(prev).map(([k, v]) => convert$lt$gtFieldTo$eq({ [k]: v }))
   );
-  return { ...previousFields, [field]: { [$gtOr$lt(sortAsc)]: value } };
+  return { ...previousFields, [field]: { [$gt$lt(sortAsc)]: value } };
 }
 
+/**
+ * tranforms
+ * ```
+ * { firstName: { $gt: "george" }
+ * ```
+ *  to
+ * ```
+ * { firstName: { $eq: "george" }
+ * ```
+ */
 function convert$lt$gtFieldTo$eq(field: { [key: string]: { $gt: any } | { $lt: any } }): {
   [key: string]: { $eq: any };
 } {

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -219,7 +219,7 @@ export function generateCursorQueryMulti(params: QueryParamsMulti) {
   const bigOr: Record<string, any>[] = [];
 
   const onlyId =
-    params.paginatedFields.length === 1 && params.paginatedFields[0].paginatedField == '_id';
+    params.paginatedFields.length === 1 && params.paginatedFields[0].paginatedField === '_id';
   if (onlyId) return { _id: { $gt: cursor } }; // TODO: check that cursor in this case will be _id and not object
 
   for (let i = 0; i < params.paginatedFields.length; i++) {

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -236,12 +236,12 @@ export function generateCursorQueryMulti(params: QueryParamsMulti) {
     params.paginatedFields.length === 1 && params.paginatedFields[0].paginatedField === '_id';
 
   if (onlyId) {
-    return getOrNextLine(
-      undefined,
-      '_id',
-      params.paginatedFields[0].sortAscending,
-      idValue ?? cursor
-    );
+    return getOrNextLine({
+      prev: undefined,
+      field: '_id',
+      sortAsc: params.paginatedFields[0].sortAscending,
+      value: idValue ?? cursor,
+    });
   }
 
   for (let i = 0; i < params.paginatedFields.length; i++) {
@@ -258,7 +258,7 @@ export function generateCursorQueryMulti(params: QueryParamsMulti) {
     const prev = bigOr[bigOr.length - 1];
 
     if (paginatedFieldValue) {
-      const newFields = getOrNextLine(prev, field, sortAsc, paginatedFieldValue);
+      const newFields = getOrNextLine({ prev, field, sortAsc, value: paginatedFieldValue });
       bigOr.push(newFields);
     } else {
       const notNullNorUndefined = { [field]: { $ne: null } };
@@ -301,7 +301,17 @@ function $gt$lt(asc: boolean) {
  *  { firstName: { $eq: "george" }, { lastName: {$gt: "Costanza" } }
  * ```
  */
-function getOrNextLine(prev: BigOrRow, field: string, sortAsc: boolean, value: string): BigOrRow {
+function getOrNextLine({
+  prev,
+  field,
+  sortAsc,
+  value,
+}: {
+  prev?: BigOrRow;
+  field: string;
+  sortAsc: boolean;
+  value: string;
+}): BigOrRow {
   if (!prev) {
     return { [field]: { [$gt$lt(sortAsc)]: value } } as BigOrRow;
   }

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -7,6 +7,7 @@ import {
   PaginationResponse,
   PaginatedField,
   QueryParamsMulti,
+  AggregateParamsMulti,
 } from '../types';
 
 import { encode } from './bsonUrlEncoding';
@@ -29,6 +30,27 @@ function buildCursor(
   return encode(rawCursor);
 }
 
+function buildCursorMulti(
+  doc: { _id: any },
+  params: QueryParamsMulti | AggregateParamsMulti,
+  shouldSecondarySortOnId: boolean
+): string {
+  const fieldValues = (() => {
+    const { paginatedFields } = params;
+    const paginatedFieldValues = {};
+    for (const field of paginatedFields) {
+      const value = objectPath.get(doc, field.paginatedField);
+      const maybeToLowerValue =
+        field.sortCaseInsensitive && value?.toLowerCase ? value.toLowerCase() : value;
+      paginatedFieldValues[field.paginatedField] = maybeToLowerValue;
+    }
+    return paginatedFieldValues;
+  })();
+
+  const rawCursor = shouldSecondarySortOnId ? { ...fieldValues, _id: doc._id } : fieldValues; // which may actually be the document_id anyways
+  return encode(rawCursor);
+}
+
 /**
  * Helper function to encode pagination tokens.
  *
@@ -39,15 +61,20 @@ function buildCursor(
  */
 export function encodePaginationTokens(
   params: QueryParams | AggregateParams,
-  response: PaginationResponse
+  response: PaginationResponse,
+  multi = false
 ): void {
   const shouldSecondarySortOnId = params.paginatedField !== '_id';
 
   if (response.previous) {
-    response.previous = buildCursor(response.previous, params, shouldSecondarySortOnId);
+    response.previous = multi
+      ? buildCursorMulti(response.previous, params, shouldSecondarySortOnId)
+      : buildCursor(response.previous, params, shouldSecondarySortOnId);
   }
   if (response.next) {
-    response.next = buildCursor(response.next, params, shouldSecondarySortOnId);
+    response.next = multi
+      ? buildCursorMulti(response.next, params, shouldSecondarySortOnId)
+      : buildCursor(response.next, params, shouldSecondarySortOnId);
   }
 }
 
@@ -62,7 +89,8 @@ export function encodePaginationTokens(
  */
 export function prepareResponse(
   results: any[],
-  params: QueryParams | AggregateParams
+  params: QueryParams | AggregateParams,
+  multi = false
 ): PaginationResponse {
   const hasMore = results.length > params.limit;
   const shouldSecondarySortOnId = params.paginatedField !== '_id';
@@ -75,7 +103,9 @@ export function prepareResponse(
 
   results = results.map((result: any) => ({
     ...result,
-    _cursor: buildCursor(result, params, shouldSecondarySortOnId),
+    _cursor: multi
+      ? buildCursorMulti(result, params, shouldSecondarySortOnId)
+      : buildCursor(result, params, shouldSecondarySortOnId),
   }));
 
   // If we sorted reverse to get the previous page, correct the sort order.
@@ -89,7 +119,7 @@ export function prepareResponse(
     hasNext,
   };
 
-  encodePaginationTokens(params, response);
+  encodePaginationTokens(params, response, multi);
 
   return response;
 }
@@ -110,7 +140,9 @@ export function generateSort(params: SearchArgs): Record<string, number> {
 
   if (params.paginatedField == '_id') return { _id: sortDir };
 
-  const field = params.sortCaseInsensitive ? '__lower_case_value' : params.paginatedField;
+  const field = params.sortCaseInsensitive
+    ? `__lower_case_value_${params.paginatedField}`
+    : params.paginatedField;
   return { [field]: sortDir };
 }
 
@@ -119,6 +151,7 @@ export function generateSorts(params: QueryParamsMulti) {
     ...pf,
     previous: params.previous,
   }));
+
   return Object.assign({}, ...sortArgs.map((f) => generateSort(f)));
 }
 
@@ -147,7 +180,6 @@ export function generateCursorQuery(params: QueryParams | AggregateParams): obje
   const notNullNorUndefined = { [field]: { $ne: null } };
   const nullOrUndefined = { [field]: null };
   const [paginatedFieldValue, idValue] = cursor;
-
   // mongo does not distinguish a sort order difference between null or undefined
   // for sorting purposes, and thus secondarily sorts by _id
   if (paginatedFieldValue === null || paginatedFieldValue === undefined) {
@@ -179,85 +211,90 @@ export function generateCursorQuery(params: QueryParams | AggregateParams): obje
       };
 }
 
-type FalsyOrAsc =
-  | {
-      [x: string]: {
-        $ne: any;
-      };
-    }
-  | {
-      _id: {
-        $gt: any;
-      };
-    };
-
-type FalsyOrDesc = {
-  _id: {
-    $lt: any;
-  };
-};
-
-type TruthyOr = {
-  [x: string]: any;
-};
-
-type MongoOr = { $or: Array<FalsyOrAsc | FalsyOrDesc | TruthyOr> };
-
 export function generateCursorQueryMulti(params: QueryParamsMulti) {
   if (!params.next && !params.previous) return {};
+
   const cursor = (params.next || params.previous) as any;
+  const idValue = cursor._id;
+  const bigOr: Record<string, any>[] = [];
 
-  const cursors: Array<FalsyOrAsc | FalsyOrDesc | TruthyOr> = []; // TODO: may want these as one big OR?
+  const onlyId =
+    params.paginatedFields.length === 1 && params.paginatedFields[0].paginatedField == '_id';
+  if (onlyId) return { _id: { $gt: cursor } }; // TODO: check that cursor in this case will be _id and not object
 
-  for (const paginatedField of params.paginatedFields) {
-    const sortAsc =
-      (!paginatedField.sortAscending && params.previous) ||
-      ((paginatedField.sortAscending && !params.previous) as boolean);
-    const onlyId =
-      params.paginatedFields.length === 1 && params.paginatedFields[0].paginatedField == '_id';
-    if (onlyId) return { _id: sortAsc ? { $gt: cursor } : { $lt: cursor } }; // early exit only the id is included
+  for (let i = 0; i < params.paginatedFields.length; i++) {
+    const pf = params.paginatedFields[i];
 
-    const field = paginatedField.sortCaseInsensitive
-      ? '__lower_case_value' // lc value of the paginatedField (via $addFields + $toLower)
-      : paginatedField.paginatedField;
+    const field = pf.sortCaseInsensitive
+      ? `__lower_case_value_${pf.paginatedField}` // lc value of the paginatedField (via $addFields + $toLower)
+      : pf.paginatedField;
 
-    const notNullNorUndefined = { [field]: { $ne: null } };
-    const nullOrUndefined = { [field]: null };
-    const [paginatedFieldValue, idValue] = cursor;
+    const sortAsc = ((!pf.sortAscending && params.previous) ||
+      (pf.sortAscending && !params.previous)) as boolean;
 
-    if (paginatedFieldValue === null || paginatedFieldValue === undefined) {
-      const falsySorts = sortAsc
-        ? [
-            notNullNorUndefined, // still have all the non-null, non-undefined values
-            { ...nullOrUndefined, _id: { $gt: idValue } },
-          ] // & sort remaining using the _id as secondary field
-        : // if sorting descending value, then all other values must be null || undefined
-          [{ ...nullOrUndefined, _id: { $lt: idValue } }];
-      cursors.push(...falsySorts);
-      continue;
+    const paginatedFieldValue = cursor[pf.paginatedField];
+    const prev = bigOr[bigOr.length - 1];
+
+    if (paginatedFieldValue) {
+      const newFields = getOrNextLine(prev, field, sortAsc, paginatedFieldValue);
+      bigOr.push(newFields);
+    } else {
+      const notNullNorUndefined = { [field]: { $ne: null } };
+      const nullOrUndefined = { [field]: null };
+
+      const previousFields = (() => {
+        if (!prev) {
+          return {};
+        }
+        return Object.assign(
+          {},
+          ...Object.entries(prev).map(([k, v]) => convert$lt$gtFieldTo$eq({ [k]: v }))
+        );
+      })();
+
+      if (sortAsc) {
+        bigOr.push({ ...previousFields, ...notNullNorUndefined });
+      } else {
+        bigOr.push({ ...previousFields, ...nullOrUndefined });
+      }
     }
-
-    const sorts = sortAsc
-      ? [
-          { [field]: { $gt: paginatedFieldValue } },
-          { [field]: { $eq: paginatedFieldValue }, _id: { $gt: idValue } },
-        ]
-      : [
-          nullOrUndefined, // in descending order, will still have null && undefined values remaining
-          { [field]: { $lt: paginatedFieldValue } },
-          { [field]: { $eq: paginatedFieldValue }, _id: { $lt: idValue } },
-        ];
-
-    cursors.push(...sorts);
   }
 
-  const defaultOr: MongoOr = { $or: [] };
+  const prev = bigOr[bigOr.length - 1];
+  const lastField = getOrNextLine(prev, '_id', true, idValue); // TODO: need a sortAsc for default fields?
+  bigOr.push(lastField);
 
-  return cursors.reduce((acc: MongoOr, curr) => {
-    acc.$or.push(curr);
-    return acc;
-  }, defaultOr);
+  return { $or: bigOr };
 }
+
+function $gtOr$lt(asc: boolean) {
+  return asc ? '$gt' : '$lt';
+}
+
+function getOrNextLine(
+  prev: Record<string, any>,
+  field: string,
+  sortAsc: boolean,
+  value: string
+): Record<string, any> {
+  if (!prev) {
+    return { [field]: { [$gtOr$lt(sortAsc)]: value } };
+  }
+  const previousFields = Object.assign(
+    {},
+    ...Object.entries(prev).map(([k, v]) => convert$lt$gtFieldTo$eq({ [k]: v }))
+  );
+  return { ...previousFields, [field]: { [$gtOr$lt(sortAsc)]: value } };
+}
+
+function convert$lt$gtFieldTo$eq(field: { [key: string]: { $gt: any } | { $lt: any } }): {
+  [key: string]: { $eq: any };
+} {
+  const [key, value] = Object.entries(field)[0];
+  const [, fieldValue] = Object.entries(value)[0];
+  return { [key]: { $eq: fieldValue } };
+}
+
 /**
  * response results can have additional fields that were not requested by user (for example, the
  * fields required to sort and paginate). If projected fields are nominated, return only these.

--- a/src/utils/sanitizeParams.ts
+++ b/src/utils/sanitizeParams.ts
@@ -50,9 +50,22 @@ export async function sanitizeMultiParamsMutate(
   collection: Collection | any,
   params: QueryInputParamsMulti
 ) {
+  // add default _id paginate sort
   if (!params.paginatedFields?.length) {
     params.paginatedFields = [];
-    params.paginatedFields.push({ paginatedField: '_id' });
+    params.paginatedFields.push({
+      paginatedField: '_id',
+      sortAscending: false,
+      sortCaseInsensitive: false,
+    });
+    // add _id to the end of the fields
+  } else if (!params.paginatedFields.find((f) => f.paginatedField === '_id')) {
+    const lastField = params?.paginatedFields[params.paginatedFields?.length - 1];
+    params.paginatedFields.push({
+      paginatedField: '_id',
+      sortAscending: lastField?.sortAscending,
+      sortCaseInsensitive: lastField?.sortCaseInsensitive,
+    });
   }
 
   // set the params.limit

--- a/src/utils/sanitizeParams.ts
+++ b/src/utils/sanitizeParams.ts
@@ -72,11 +72,13 @@ export async function sanitizeMultiParamsMutate(
   if (params.fields) {
     const { fields: requestedFields, paginatedFields } = params;
 
-    params.fields = {
-      _id: 0,
-      ...requestedFields,
-      ...paginatedFields.map((pf) => ({ [pf.paginatedField]: 1 })),
-    };
+    params.fields = Object.assign(
+      {
+        _id: 0,
+      },
+      requestedFields,
+      ...paginatedFields.map((pf) => ({ [pf.paginatedField]: 1 }))
+    );
   }
 
   return params;

--- a/test/findMulti.test.ts
+++ b/test/findMulti.test.ts
@@ -1,0 +1,235 @@
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { Collection, Db, Document, ObjectId } from 'mongodb';
+import _ from 'underscore';
+
+import { findMulti, config, find } from '../src';
+import dbUtils from './support/db';
+
+let mongod: MongoMemoryServer;
+
+describe('findMulti', () => {
+  let db: Db;
+  beforeAll(async () => {
+    mongod = await dbUtils.start();
+    db = await dbUtils.db(mongod);
+
+    await db.collection('test_deep_sorts').insertMany([
+      {
+        title: 'Mr',
+        firstName: 'Aguste',
+        lastName: 'Teasey',
+        birthYear: 1921,
+        favouriteFood: 'potatoes',
+      },
+      {
+        title: 'Mr',
+        firstName: 'Aguste',
+        lastName: 'Pedden',
+        birthYear: 1922,
+        favouriteFood: 'pizza',
+      },
+      {
+        title: 'Mr',
+        firstName: 'Aguste',
+        lastName: 'Saunt',
+        birthYear: 1923,
+        favouriteFood: 'potatoes',
+      },
+      {
+        title: 'Mr',
+        firstName: 'Graig',
+        lastName: 'Maciunas',
+        birthYear: 1921,
+        favouriteFood: 'potatoes',
+      },
+      {
+        title: 'Mr',
+        firstName: "D'arcy",
+        lastName: 'Sachno',
+        birthYear: 1922,
+        favouriteFood: 'pizza',
+      },
+      {
+        title: 'Mrs',
+        firstName: 'Jae',
+        lastName: 'Petrazzi',
+        birthYear: 1923,
+        favouriteFood: 'potatoes',
+      },
+      {
+        title: 'Mrs',
+        firstName: 'Flore',
+        lastName: 'Ternouth',
+        birthYear: 1921,
+        favouriteFood: 'potatoes',
+      },
+      {
+        title: 'Mrs',
+        firstName: 'Ines',
+        lastName: 'Richarson',
+        birthYear: 1922,
+        favouriteFood: 'pizza',
+      },
+      {
+        title: 'Mrs',
+        firstName: 'Carmencita',
+        lastName: 'Hallibone',
+        birthYear: 1923,
+        favouriteFood: 'potatoes',
+      },
+      {
+        title: 'Mrs',
+        firstName: 'Wilmar',
+        lastName: 'Petrov',
+        birthYear: 1921,
+        favouriteFood: 'pizza',
+      },
+    ]);
+  });
+
+  afterAll(() => mongod.stop());
+
+  beforeEach(() => {
+    config.COLLATION = undefined;
+  });
+
+  async function runPaginateTest(caseInsensitive: boolean) {
+    const collection = db.collection('test_deep_sorts');
+
+    async function findMultiWithPrev(next: any = undefined) {
+      return findMulti(collection, {
+        limit: 3,
+        next,
+        paginatedFields: [
+          {
+            paginatedField: 'firstName',
+            sortCaseInsensitive: caseInsensitive,
+            sortAscending: true,
+          },
+          { paginatedField: 'lastName', sortCaseInsensitive: caseInsensitive, sortAscending: true },
+        ],
+      });
+    }
+
+    const res1 = await findMultiWithPrev();
+    const res2 = await findMultiWithPrev(res1.next);
+    const res3 = await findMultiWithPrev(res2.next);
+    const res4 = await findMultiWithPrev(res3.next);
+    const res5 = await findMultiWithPrev(res4.next);
+
+    // sort by first name then last should result in the
+    // first names being equal meaning the next sort takes precedence
+    expect(res1.results[0].firstName).toEqual('Aguste');
+    expect(res1.results[1].firstName).toEqual('Aguste');
+    expect(res1.results[2].firstName).toEqual('Aguste');
+    expect(res1.results[0].lastName).toEqual('Pedden');
+    expect(res1.results[1].lastName).toEqual('Saunt');
+    expect(res1.results[2].lastName).toEqual('Teasey');
+
+    // after a bunch of paginations, the last result should still be sorted
+    expect(res4.results[0].firstName).toEqual('Wilmar');
+    expect(res4.results[0].lastName).toEqual('Petrov');
+
+    // last result should be blank
+    expect(res5.results.length).toEqual(0);
+    expect(res5.hasPrevious).toEqual(true);
+    expect(res5.hasNext).toEqual(false);
+  }
+
+  it('paginates by multiple fields', async () => {
+    await runPaginateTest(false);
+  });
+
+  it('paginates by multiple fields case insensitive', async () => {
+    await runPaginateTest(true);
+  });
+
+  it('handles a bunch of nested sorts', async () => {
+    const collection = db.collection('test_deep_sorts');
+
+    async function findMultiWithPrev(next: any = undefined) {
+      return findMulti(collection, {
+        limit: 3,
+        next,
+        paginatedFields: [
+          { paginatedField: 'title', sortCaseInsensitive: false, sortAscending: true },
+          { paginatedField: 'favouriteFood', sortCaseInsensitive: false, sortAscending: true },
+          { paginatedField: 'birthYear', sortCaseInsensitive: false, sortAscending: true },
+          { paginatedField: 'firstName', sortCaseInsensitive: false, sortAscending: true },
+          { paginatedField: 'lastName', sortCaseInsensitive: false, sortAscending: true },
+        ],
+      });
+    }
+
+    const res1 = await findMultiWithPrev();
+    const res2 = await findMultiWithPrev(res1.next);
+
+    const combinedResults = [...res1.results, ...res2.results];
+
+    // there's 5 "Mr" in the collection so the first 5 should be "mr" followed by a mrs
+    for (const result of combinedResults.slice(0, 5)) {
+      expect(result.title).toEqual('Mr');
+    }
+    expect(combinedResults[combinedResults.length - 1].title).toEqual('Mrs');
+
+    // of the 5 Mr, the first 2 should be "pizza", next 3 should be potatoes
+    for (const result of combinedResults.slice(0, 2)) {
+      expect(result.favouriteFood).toEqual('pizza');
+    }
+    for (const result of combinedResults.slice(2, 5)) {
+      expect(result.favouriteFood).toEqual('potatoes');
+    }
+
+    // of the potatoes, the first two birthyear should be  sorted 1921 followed by 1923
+    for (const result of combinedResults.slice(2, 4)) {
+      expect(result.birthYear).toEqual(1921);
+    }
+    expect(combinedResults[4].birthYear).toEqual(1923);
+
+    // of the 1921's, they should be sorted by firstName
+    expect(combinedResults[2].firstName).toEqual('Aguste');
+    expect(combinedResults[3].firstName).toEqual('Graig');
+  });
+
+  it('behaves the same as find given the same arguments', async () => {
+    const collection = db.collection('test_deep_sorts');
+
+    const findResult1 = await find(collection, {
+      limit: 3,
+      paginatedField: 'firstName',
+      sortCaseInsensitive: false,
+      sortAscending: true,
+    });
+
+    const findMultiResult1 = await findMulti(collection, {
+      limit: 3,
+      paginatedFields: [
+        { paginatedField: 'firstName', sortCaseInsensitive: true, sortAscending: true },
+      ],
+    });
+
+    expect(findResult1.results.map((r) => r._id)).toEqual(
+      findMultiResult1.results.map((r) => r._id)
+    );
+
+    const findResult2 = await find(collection, {
+      limit: 3,
+      next: findResult1.next,
+      paginatedField: 'firstName',
+      sortCaseInsensitive: false,
+      sortAscending: true,
+    });
+
+    const findMultiResult2 = await findMulti(collection, {
+      limit: 3,
+      next: findMultiResult1.next,
+      paginatedFields: [
+        { paginatedField: 'firstName', sortCaseInsensitive: true, sortAscending: true },
+      ],
+    });
+
+    expect(findResult2.results.map((r) => r._id)).toEqual(
+      findMultiResult2.results.map((r) => r._id)
+    );
+  });
+});

--- a/test/findMulti.test.ts
+++ b/test/findMulti.test.ts
@@ -15,74 +15,84 @@ describe('findMulti', () => {
 
     await db.collection('test_deep_sorts').insertMany([
       {
+        _id: new ObjectId('64cb29a1b2a41fc8221041b1'),
         title: 'Mr',
         firstName: 'Aguste',
         lastName: 'Teasey',
         birthYear: 1921,
-        favouriteFood: 'potatoes',
+        favoriteFood: 'potatoes',
       },
       {
+        _id: new ObjectId('64cb29a1b2a41fc8221041b2'),
         title: 'Mr',
         firstName: 'Aguste',
         lastName: 'Pedden',
         birthYear: 1922,
-        favouriteFood: 'pizza',
+        favoriteFood: 'pizza',
       },
       {
+        _id: new ObjectId('64cb29a1b2a41fc8221041b0'),
         title: 'Mr',
         firstName: 'Aguste',
         lastName: 'Saunt',
         birthYear: 1923,
-        favouriteFood: 'potatoes',
+        favoriteFood: 'potatoes',
       },
       {
+        _id: new ObjectId('64cb29a1b2a41fc8221041b8'),
         title: 'Mr',
         firstName: 'Graig',
         lastName: 'Maciunas',
         birthYear: 1921,
-        favouriteFood: 'potatoes',
+        favoriteFood: 'potatoes',
       },
       {
+        _id: new ObjectId('64cb29a1b2a41fc8221041b4'),
         title: 'Mr',
         firstName: "D'arcy",
         lastName: 'Sachno',
         birthYear: 1922,
-        favouriteFood: 'pizza',
+        favoriteFood: 'pizza',
       },
       {
+        _id: new ObjectId('64cb29a1b2a41fc8221041b6'),
         title: 'Mrs',
-        firstName: 'Jae',
+        firstName: 'Wilmar',
         lastName: 'Petrazzi',
         birthYear: 1923,
-        favouriteFood: 'potatoes',
+        favoriteFood: 'potatoes',
       },
       {
+        _id: new ObjectId('64cb29a1b2a41fc8221041b3'),
         title: 'Mrs',
         firstName: 'Flore',
         lastName: 'Ternouth',
         birthYear: 1921,
-        favouriteFood: 'potatoes',
+        favoriteFood: 'potatoes',
       },
       {
+        _id: new ObjectId('64cb29a1b2a41fc8221041b7'),
         title: 'Mrs',
         firstName: 'Ines',
         lastName: 'Richarson',
         birthYear: 1922,
-        favouriteFood: 'pizza',
+        favoriteFood: 'pizza',
       },
       {
+        _id: new ObjectId('64cb29a1b2a41fc8221041b5'),
         title: 'Mrs',
         firstName: 'Carmencita',
         lastName: 'Hallibone',
         birthYear: 1923,
-        favouriteFood: 'potatoes',
+        favoriteFood: 'potatoes',
       },
       {
+        _id: new ObjectId('64cb29a1b2a41fc8221041b9'),
         title: 'Mrs',
         firstName: 'Wilmar',
         lastName: 'Petrov',
         birthYear: 1921,
-        favouriteFood: 'pizza',
+        favoriteFood: 'pizza',
       },
     ]);
   });
@@ -153,7 +163,7 @@ describe('findMulti', () => {
         next,
         paginatedFields: [
           { paginatedField: 'title', sortCaseInsensitive: false, sortAscending: true },
-          { paginatedField: 'favouriteFood', sortCaseInsensitive: false, sortAscending: true },
+          { paginatedField: 'favoriteFood', sortCaseInsensitive: false, sortAscending: true },
           { paginatedField: 'birthYear', sortCaseInsensitive: false, sortAscending: true },
           { paginatedField: 'firstName', sortCaseInsensitive: false, sortAscending: true },
           { paginatedField: 'lastName', sortCaseInsensitive: false, sortAscending: true },
@@ -174,10 +184,10 @@ describe('findMulti', () => {
 
     // of the 5 Mr, the first 2 should be "pizza", next 3 should be potatoes
     for (const result of combinedResults.slice(0, 2)) {
-      expect(result.favouriteFood).toEqual('pizza');
+      expect(result.favoriteFood).toEqual('pizza');
     }
     for (const result of combinedResults.slice(2, 5)) {
-      expect(result.favouriteFood).toEqual('potatoes');
+      expect(result.favoriteFood).toEqual('potatoes');
     }
 
     // of the potatoes, the first two birthyear should be  sorted 1921 followed by 1923
@@ -231,5 +241,109 @@ describe('findMulti', () => {
     expect(findResult2.results.map((r) => r._id)).toEqual(
       findMultiResult2.results.map((r) => r._id)
     );
+  });
+
+  it('sorts by _id by default', async () => {
+    const collection = db.collection('test_deep_sorts');
+
+    const result1 = await findMulti(collection, {
+      limit: 3,
+    });
+    const result2 = await findMulti(collection, {
+      next: result1.next,
+      limit: 3,
+    });
+
+    const ids = [...result1.results, ...result2.results].map((r) => `${r._id}`);
+
+    expect(ids).toEqual([
+      '64cb29a1b2a41fc8221041b9',
+      '64cb29a1b2a41fc8221041b8',
+      '64cb29a1b2a41fc8221041b7',
+      '64cb29a1b2a41fc8221041b6',
+      '64cb29a1b2a41fc8221041b5',
+      '64cb29a1b2a41fc8221041b4',
+    ]);
+  });
+
+  it('sorts by _id the other way', async () => {
+    const collection = db.collection('test_deep_sorts');
+
+    const result1 = await findMulti(collection, {
+      limit: 3,
+      paginatedFields: [{ paginatedField: '_id', sortCaseInsensitive: false, sortAscending: true }],
+    });
+    const result2 = await findMulti(collection, {
+      next: result1.next,
+      limit: 3,
+      paginatedFields: [{ paginatedField: '_id', sortCaseInsensitive: false, sortAscending: true }],
+    });
+
+    const ids = [...result1.results, ...result2.results].map((r) => `${r._id}`);
+
+    expect(ids).toEqual([
+      '64cb29a1b2a41fc8221041b0',
+      '64cb29a1b2a41fc8221041b1',
+      '64cb29a1b2a41fc8221041b2',
+      '64cb29a1b2a41fc8221041b3',
+      '64cb29a1b2a41fc8221041b4',
+      '64cb29a1b2a41fc8221041b5',
+    ]);
+  });
+
+  it('sorts by _id after all other sorts in the same direction as last sort', async () => {
+    const collection = db.collection('test_deep_sorts');
+
+    const result1 = await findMulti(collection, {
+      limit: 3,
+      paginatedFields: [
+        { paginatedField: 'firstName', sortCaseInsensitive: false, sortAscending: true },
+      ],
+    });
+    const result2 = await findMulti(collection, {
+      next: result1.next,
+      limit: 3,
+      paginatedFields: [
+        { paginatedField: 'firstName', sortCaseInsensitive: false, sortAscending: true },
+      ],
+    });
+
+    const ids = [...result1.results, ...result2.results].map((r) => `${r._id}`);
+
+    // for people of the same first name their ids should be ascending
+    expect(ids).toEqual([
+      '64cb29a1b2a41fc8221041b0', // Aguste
+      '64cb29a1b2a41fc8221041b1', // Aguste
+      '64cb29a1b2a41fc8221041b2', // Aguste
+      '64cb29a1b2a41fc8221041b5', // Carmencita
+      '64cb29a1b2a41fc8221041b4', // D'arcy
+      '64cb29a1b2a41fc8221041b3', // Flore
+    ]);
+
+    const result3 = await findMulti(collection, {
+      limit: 3,
+      paginatedFields: [
+        { paginatedField: 'firstName', sortCaseInsensitive: false, sortAscending: false },
+      ],
+    });
+    const result4 = await findMulti(collection, {
+      next: result3.next,
+      limit: 3,
+      paginatedFields: [
+        { paginatedField: 'firstName', sortCaseInsensitive: false, sortAscending: false },
+      ],
+    });
+
+    const ids2 = [...result3.results, ...result4.results].map((r) => `${r._id}`);
+
+    // for people of the same first name their ids should be descending
+    expect(ids2).toEqual([
+      '64cb29a1b2a41fc8221041b9', // Wilmar
+      '64cb29a1b2a41fc8221041b6', // Wilmar
+      '64cb29a1b2a41fc8221041b7', // Ines
+      '64cb29a1b2a41fc8221041b8', // Graig
+      '64cb29a1b2a41fc8221041b3', // Flore
+      '64cb29a1b2a41fc8221041b4', // D'arcy
+    ]);
   });
 });

--- a/test/mongoosePlugin.test.ts
+++ b/test/mongoosePlugin.test.ts
@@ -7,7 +7,11 @@ import dbUtils from './support/db';
 const AuthorSchema = new Schema({ name: String });
 AuthorSchema.index({ name: 'text' });
 
-AuthorSchema.plugin(mongooseCursorPaginate, { name: 'paginateFN', searchFnName: 'searchFN' });
+AuthorSchema.plugin(mongooseCursorPaginate, {
+  name: 'paginateFN',
+  searchFnName: 'searchFN',
+  findMultiFnName: 'findMultiFn',
+});
 
 type ModelSchemaType = typeof Model;
 interface AuthorSchemaWithPlugin extends ModelSchemaType {

--- a/test/sanitize.test.ts
+++ b/test/sanitize.test.ts
@@ -13,43 +13,37 @@ describe('sanitize', () => {
   let paramsMulti;
 
   beforeEach(() => {
-    baseParams = {
-      next: 'WyJfX21peG1heF9fdW5kZWZpbmVkX18iLHsiJG9pZCI6IjY0YzMzOTlkNmNmYzc1YzNlMmY5ZDEyZCJ9XQ',
-      previous:
-        'WyJfX21peG1heF9fdW5kZWZpbmVkX18iLHsiJG9pZCI6IjY0YzMzOTlkNmNmYzc1YzNlMmY5ZDEyNiJ9XQ',
-      limit: 2,
-    };
-
     params = {
       paginatedField: 'created_at',
-      ...baseParams,
+      // ["created_at",{"$oid":"64cb29a1b2a41fc8221041b2"}]
+      next: 'WyJjcmVhdGVkX2F0Iix7IiRvaWQiOiI2NGNiMjlhMWIyYTQxZmM4MjIxMDQxYjIifV0=',
+      limit: 2,
     };
 
     paramsMulti = {
       paginatedFields: [{ paginatedField: 'created_at' }],
-      ...baseParams,
+      // {"created_at":"10-06-1992","_id":{"$oid":"64cb29a1b2a41fc8221041b2"}}
+      next: 'eyJjcmVhdGVkX2F0IjoiMTAtMDYtMTk5MiIsIl9pZCI6eyIkb2lkIjoiNjRjYjI5YTFiMmE0MWZjODIyMTA0MWIyIn19',
+      limit: 2,
     };
   });
 
-  it('sanitizie and sanitizeMulti do the same thing given the same arguments', async () => {
+  it('sanitize and sanitizeMulti do the same thing given the same arguments', async () => {
     const s = await sanitizeParams({}, params);
     const sm = await sanitizeMultiParamsMutate({}, paramsMulti);
     // these produce slightly different shapes, but the same data
     expect(s.paginatedField).toEqual(sm.paginatedFields![0].paginatedField);
   });
 
-  it('generateCursorQuery and generateCursorQueryMulti do the same thing given the same arguments', () => {
-    const cq = generateCursorQuery(params);
-    const cqm = generateCursorQueryMulti(paramsMulti);
-    expect(cq).toEqual(cqm);
-  });
-
   it('generateSort and generateSorts do the same thing given the same arguments', async () => {
     const sanitizedParams = await sanitizeParams({}, params);
     const sanitizedParamsMulti = await sanitizeMultiParamsMutate({}, paramsMulti);
 
+    // params multi adds the _id to the sort explicitly instead of tacking it on like the old one did.
+
     const s = generateSort(sanitizedParams);
     const sm = generateSorts(sanitizedParamsMulti);
-    expect(s).toEqual(sm);
+
+    expect(s?.created_at).toEqual(sm.created_at);
   });
 });

--- a/test/sanitize.test.ts
+++ b/test/sanitize.test.ts
@@ -1,0 +1,55 @@
+import { QueryInputParams, QueryInputParamsMulti } from '../src/types';
+import {
+  generateCursorQuery,
+  generateCursorQueryMulti,
+  generateSort,
+  generateSorts,
+} from '../src/utils/query';
+import sanitizeParams, { sanitizeMultiParamsMutate } from '../src/utils/sanitizeParams';
+
+describe('sanitize', () => {
+  let baseParams;
+  let params;
+  let paramsMulti;
+
+  beforeEach(() => {
+    baseParams = {
+      next: 'WyJfX21peG1heF9fdW5kZWZpbmVkX18iLHsiJG9pZCI6IjY0YzMzOTlkNmNmYzc1YzNlMmY5ZDEyZCJ9XQ',
+      previous:
+        'WyJfX21peG1heF9fdW5kZWZpbmVkX18iLHsiJG9pZCI6IjY0YzMzOTlkNmNmYzc1YzNlMmY5ZDEyNiJ9XQ',
+      limit: 2,
+    };
+
+    params = {
+      paginatedField: 'created_at',
+      ...baseParams,
+    };
+
+    paramsMulti = {
+      paginatedFields: [{ paginatedField: 'created_at' }],
+      ...baseParams,
+    };
+  });
+
+  it('sanitizie and sanitizeMulti do the same thing given the same arguments', async () => {
+    const s = await sanitizeParams({}, params);
+    const sm = await sanitizeMultiParamsMutate({}, paramsMulti);
+    // these produce slightly different shapes, but the same data
+    expect(s.paginatedField).toEqual(sm.paginatedFields![0].paginatedField);
+  });
+
+  it('generateCursorQuery and generateCursorQueryMulti do the same thing given the same arguments', () => {
+    const cq = generateCursorQuery(params);
+    const cqm = generateCursorQueryMulti(paramsMulti);
+    expect(cq).toEqual(cqm);
+  });
+
+  it('generateSort and generateSorts do the same thing given the same arguments', async () => {
+    const sanitizedParams = await sanitizeParams({}, params);
+    const sanitizedParamsMulti = await sanitizeMultiParamsMutate({}, paramsMulti);
+
+    const s = generateSort(sanitizedParams);
+    const sm = generateSorts(sanitizedParamsMulti);
+    expect(s).toEqual(sm);
+  });
+});


### PR DESCRIPTION
NOTE: unsure how to do the versioning on this, whether I just make it 8.8.1 and it'll just werk or what.

#### Changes Made

- allows paginated query with array of paginated fields using the new `paginateMulti` method
```
    const result = await Message.paginateMulti({
      paginatedFields: [
        { paginatedField: 'user_id', sortAscending: false },
        { paginatedField: 'created_at', sortAscending: false },
      ],
    })
    
    // user1 message1
    // user1 message2
    // user2 message1
    // user2 message2
```
- fixes sorts on the original `find` (`paginate`) function as well so now case insensitivity must be specified

#### Potential Risks
- small change to `paginate` function may mean that results will be returned in a different order than they were before
