### PR TITLE
bugfix#2714 Cannot read properties of undefined (reading 'n') error when doing aggregrate search and no results present

### DIFF
--- a/src/findMulti.ts
+++ b/src/findMulti.ts
@@ -74,8 +74,9 @@ export default async (
         const result = await (collection as Collection)
           .aggregate([...query, { $group: { _id: null, n: { $sum: 1 } } }])
           .toArray();
+          
 
-        response.totalCount = result[0].n;
+        response.totalCount = result?.[0]?.n ?? 0;
       } else {
         response.totalCount = await collection.countDocuments(params.query);
       }


### PR DESCRIPTION
### Before (the problem):
<img width="636" alt="Screenshot 2024-02-22 at 5 40 50 pm" src="https://github.com/conpagoaus/mongo-cursor-pagination/assets/52943748/5c89ede7-f46e-478d-9951-45d416b24c39">

### Change:
<img width="885" alt="Screenshot 2024-02-22 at 5 41 15 pm" src="https://github.com/conpagoaus/mongo-cursor-pagination/assets/52943748/c247192a-de1a-4e34-a495-a666ac196d6a">

### After:
**No errors, when there are no results. with the aggregate search**
