### PR TITLE
Bump package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conpago/mongo-cursor-pagination",
-  "version": "8.8.5",
+  "version": "8.8.7",
   "description": "Make it easy to return cursor-paginated results from a Mongo collection",
   "main": "index.js",
   "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
Bumping version in package json to the next version to be released (`8.8.7`) - looks like [someone released `8.8.6`](https://www.npmjs.com/package/@conpago/mongo-cursor-pagination/v/8.8.6) last month and forgot to bump it here (hence why updating the below from `8.8.5` to `8.8.7`


Just is the pre-release step. After this PR has been merged, we will release this new version to npm