### PR TITLE
bugfix#3050 Can paginate before the first page of runners to get an empty page

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "homepage": "https://github.com/conpagoaus/mongo-cursor-pagination#readme",
   "dependencies": {
-    "base64-url": "^2.3.3",
     "bson": "^6.8.0",
     "lodash": "^4.17.21",
     "object-path": "^0.11.8",
@@ -51,7 +50,6 @@
     "@eslint/js": "^9.7.0",
     "@mixmaxhq/commitlint-jenkins": "^1.6.0",
     "@mixmaxhq/semantic-release-config": "github:mixmaxhq/semantic-release-config",
-    "@types/base64-url": "^2.2.2",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.17.7",
     "@types/node": "^20.14.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      base64-url:
-        specifier: ^2.3.3
-        version: 2.3.3
       bson:
         specifier: ^6.8.0
         version: 6.8.0
@@ -42,9 +39,6 @@ importers:
       '@mixmaxhq/semantic-release-config':
         specifier: github:mixmaxhq/semantic-release-config
         version: https://codeload.github.com/mixmaxhq/semantic-release-config/tar.gz/0ec3f897a8236d44add9567a8e5012a034826fd0
-      '@types/base64-url':
-        specifier: ^2.2.2
-        version: 2.2.2
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.12
@@ -816,9 +810,6 @@ packages:
   '@types/babel__traverse@7.20.5':
     resolution: {integrity: sha512-WXCyOcRtH37HAUkpXhUduaxdm82b4GSlyTqajXviN4EfiuPgNYR109xMCKvpl6zPIpua0DGlMEDCq+g8EdoheQ==}
 
-  '@types/base64-url@2.2.2':
-    resolution: {integrity: sha512-tUtfDSDqGZ3QaYdlg0c2pP9NUBh6lRfzjudgrgOByqpfv5mg724X2xYjaNRDa1UPQqewdrPtW6sqDzYXrg+9yA==}
-
   '@types/conventional-commits-parser@5.0.0':
     resolution: {integrity: sha512-loB369iXNmAZglwWATL+WRe+CRMmmBPtpolYzIebFaX4YA3x+BEfLqhUAV9WanycKI3TG1IMr5bMJDajDKLlUQ==}
 
@@ -1122,10 +1113,6 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
-  base64-url@2.3.3:
-    resolution: {integrity: sha512-dLMhIsK7OplcDauDH/tZLvK7JmUZK3A7KiQpjNzsBrM6Etw7hzNI1tLEywqJk9NnwkgWuFKSlx/IUO7vF6Mo8Q==}
-    engines: {node: '>=6'}
 
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
@@ -5709,8 +5696,6 @@ snapshots:
     dependencies:
       '@babel/types': 7.24.0
 
-  '@types/base64-url@2.2.2': {}
-
   '@types/conventional-commits-parser@5.0.0':
     dependencies:
       '@types/node': 20.14.11
@@ -6062,8 +6047,6 @@ snapshots:
     optional: true
 
   base64-js@1.5.1: {}
-
-  base64-url@2.3.3: {}
 
   bcrypt-pbkdf@1.0.2:
     dependencies:

--- a/src/utils/bsonUrlEncoding.ts
+++ b/src/utils/bsonUrlEncoding.ts
@@ -19,12 +19,14 @@ function _decode(str: string): string {
 
 export const encode = (obj: string | object | Document): string => {
   if (Array.isArray(obj) && obj[0] === undefined) obj[0] = BSON_UNDEFINED;
+  else if (typeof obj === "string" && obj === "") return obj;
   return _encode(
     typeof obj === "string" ? obj : EJSON.stringify(obj, { relaxed: true })
   );
 };
 
 export const decode = (str: string): Document | string | undefined => {
+  if (str === "") return str;
   const obj = EJSON.parse(_decode(str), { relaxed: true });
   if (Array.isArray(obj) && obj[0] === BSON_UNDEFINED) obj[0] = undefined;
   return obj as Document;

--- a/src/utils/bsonUrlEncoding.ts
+++ b/src/utils/bsonUrlEncoding.ts
@@ -1,4 +1,3 @@
-import base64url from "base64-url";
 import { EJSON } from "bson";
 import { Document } from "mongodb";
 
@@ -10,15 +9,23 @@ const BSON_UNDEFINED = "__mixmax__undefined__";
  * as a string which can be passed in a URL.
  */
 
+function _encode(str: string): string {
+  return Buffer.from(encodeURIComponent(str)).toString("base64");
+}
+
+function _decode(str: string): string {
+  return decodeURIComponent(Buffer.from(str, "base64").toString());
+}
+
 export const encode = (obj: string | object | Document): string => {
   if (Array.isArray(obj) && obj[0] === undefined) obj[0] = BSON_UNDEFINED;
-  return base64url.encode(
+  return _encode(
     typeof obj === "string" ? obj : EJSON.stringify(obj, { relaxed: true })
   );
 };
 
 export const decode = (str: string): Document | string | undefined => {
-  const obj = EJSON.parse(base64url.decode(str), { relaxed: true });
+  const obj = EJSON.parse(_decode(str), { relaxed: true });
   if (Array.isArray(obj) && obj[0] === BSON_UNDEFINED) obj[0] = undefined;
   return obj as Document;
 };

--- a/test/encodeDecode.test.ts
+++ b/test/encodeDecode.test.ts
@@ -1,6 +1,6 @@
 import { encode, decode } from "../src/utils/bsonUrlEncoding";
 import { ObjectId } from "mongodb";
-
+import { EJSON } from "bson";
 const testObject = {
   first_name: "Tim",
   last_name: "O’Leary",
@@ -41,5 +41,11 @@ describe("bsonUrlEncoding", () => {
 
     const decoded = decode(encoded);
     expect(decoded).toBe(emptyString);
+  });
+
+  test("should be able to JSON.stringify and JSON.parse the encoded string", () => {
+    const encoded = encode(testObject);
+    const decoded = EJSON.parse(EJSON.stringify(decode(encoded)));
+    expect(decoded).toEqual(testObject);
   });
 });

--- a/test/encodeDecode.test.ts
+++ b/test/encodeDecode.test.ts
@@ -1,0 +1,45 @@
+import { encode, decode } from "../src/utils/bsonUrlEncoding";
+import { ObjectId } from "mongodb";
+
+const testObject = {
+  first_name: "Tim",
+  last_name: "O’Leary",
+  _id: new ObjectId("66b957b183c12a144ec4ad7f"),
+};
+
+describe("bsonUrlEncoding", () => {
+  test("should encode and decode a simple object correctly", () => {
+    const encoded = encode(testObject);
+    const decoded = decode(encoded);
+    expect(decoded).toEqual(testObject);
+  });
+
+  test("should handle undefined values in arrays", () => {
+    const objWithUndefinedArray = { ...testObject, arr: [undefined] };
+    const encoded = encode(objWithUndefinedArray);
+    const decoded = decode(encoded);
+    expect(decoded).toEqual({ ...testObject, arr: [null] });
+  });
+
+  test("should handle string input correctly", () => {
+    const testString = { t: "Hello, World!" };
+    const encoded = encode(testString);
+    const decoded = decode(encoded);
+    expect(decoded).toEqual(testString);
+  });
+
+  test("should handle empty object correctly", () => {
+    const emptyObject = {};
+    const encoded = encode(emptyObject);
+    const decoded = decode(encoded);
+    expect(decoded).toEqual(emptyObject);
+  });
+
+  test("should handle empty string correctly", () => {
+    const emptyString = "";
+    const encoded = encode(emptyString);
+
+    const decoded = decode(encoded);
+    expect(decoded).toBe(emptyString);
+  });
+});

--- a/test/encodeDecode.test.ts
+++ b/test/encodeDecode.test.ts
@@ -1,6 +1,7 @@
 import { encode, decode } from "../src/utils/bsonUrlEncoding";
-import { ObjectId } from "mongodb";
+import { ObjectId, Binary, Int32, Long, Decimal128 } from "mongodb";
 import { EJSON } from "bson";
+
 const testObject = {
   first_name: "Tim",
   last_name: "O’Leary",
@@ -38,7 +39,6 @@ describe("bsonUrlEncoding", () => {
   test("should handle empty string correctly", () => {
     const emptyString = "";
     const encoded = encode(emptyString);
-
     const decoded = decode(encoded);
     expect(decoded).toBe(emptyString);
   });
@@ -47,5 +47,26 @@ describe("bsonUrlEncoding", () => {
     const encoded = encode(testObject);
     const decoded = EJSON.parse(EJSON.stringify(decode(encoded)));
     expect(decoded).toEqual(testObject);
+  });
+
+  test("should handle EJSON Date correctly", () => {
+    const dateObject = { date: new Date() };
+    const encoded = encode(dateObject);
+    const decoded = decode(encoded);
+    expect(decoded).toEqual(dateObject);
+  });
+
+  test("should handle EJSON Binary correctly", () => {
+    const binaryObject = { binary: new Binary(Buffer.from("test")) };
+    const encoded = encode(binaryObject);
+    const decoded = decode(encoded);
+    expect(decoded).toEqual(binaryObject);
+  });
+
+  test("should handle EJSON Decimal128 correctly", () => {
+    const decimal128Object = { decimal128: Decimal128.fromString("123.456") };
+    const encoded = encode(decimal128Object);
+    const decoded = decode(encoded);
+    expect(decoded).toEqual(decimal128Object);
   });
 });


### PR DESCRIPTION
Remove base64-url package in favor of internal node functionality.
Please note, as this is a fork, there are 99 tests that are failing, so basically no reason to support it at this stage. Saying that, there is a unit test for new func: `tests/encodeDecode.test.ts`, but don't run the whole suite

Manual test for it is: 

```JavaScript
import { EJSON, ObjectId } from 'bson'

function encode(str: string): string {
  return Buffer.from(encodeURIComponent(str)).toString('base64')
}

function decode(str: string): string {
  return decodeURIComponent(Buffer.from(str, 'base64').toString())
}

const testObject = {
  first_name: 'Tim',
  last_name: 'O’Leary',
  _id: new ObjectId('66b957b183c12a144ec4ad7f'),
}

const bsoned = EJSON.stringify(testObject, { relaxed: true })
const encoded = encode(bsoned)
const decoded = decode(encoded)

console.warn(encoded)
console.warn('\n')
console.warn(decoded)
```

If you take the encoded value and deBase64 it and do URL parse, gives you the value back while still being a URL safe encoder.