### PR TITLE
 [Part 3] bugfix#3847 Pagination is busted when paginating back with paginatedContextUsers #13 

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ export default {
   /**
    * {Number} The maximum limit (page size).
    */
-  MAX_LIMIT: 300,
+  MAX_LIMIT: 700,
 
   /**
    * {Number} The default limit (page size), if none is specified.


### PR DESCRIPTION
- [feat(max limit): set to 700](https://github.com/conpagoaus/mongo-cursor-pagination/commit/0b54acee93024b6dda392b7eaa6cd1c22f6bd927)